### PR TITLE
[Code style] Usar espaços para indentação

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,13 +4,13 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_size = 4
-indent_style = tab
+indent_style = space
 trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.{html,js}]
-indent_size = 4
-indent_style = tab
+indent_size = 2
+indent_style = space
 
 [*.yml]
 indent_size = 4


### PR DESCRIPTION
Resolve #4, e previne warnings do flake8 pois espaços são recomendados pela [PEP8](https://www.python.org/dev/peps/pep-0008/#tabs-or-spaces)

.editorconfig para referência: [Django](https://github.com/django/django/blob/master/.editorconfig), [django-model-utils](https://github.com/jazzband/django-model-utils/blob/master/.editorconfig), [Vue.js](https://github.com/vuejs/vue/blob/master/.editorconfig)

